### PR TITLE
Add CNAME to publish step

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[.yml,.yaml,.json]
+indent_size = 2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - run: npm install
-      
+
       - run: npm run build
 
       - name: Publish to GitHub Pages
@@ -33,3 +33,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+          cname: shanemyrick.com


### PR DESCRIPTION
The CNAME file is deleted on every publish to the `gh-pages` branch. There is a setting to easily set the file on the action

https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-add-cname-file-cname