### PR TITLE
Add Bluesky domain verification

### DIFF
--- a/public/.well-known/atproto-did
+++ b/public/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:sx73xl2n3kyahaupqfgd4uvu


### PR DESCRIPTION
## What changed

Adds `public/.well-known/atproto-did` with the DID for `@shanemyrick.bsky.social`.

## Why

This lets Bluesky resolve `shanemyrick.com` to the existing account through AT Protocol's HTTPS well-known handle verification method. After deployment, the account handle can be changed to `@shanemyrick.com` without affecting the website or GitHub Pages custom-domain configuration.

## Validation

- Resolved the existing Bluesky profile to `did:plc:sx73xl2n3kyahaupqfgd4uvu`.
- Re-read the committed file from the PR branch and confirmed the exact DID contents.
- Confirmed the existing Astro build copies `public/` into the deployed `dist/` artifact.

## After merge

1. Wait for the GitHub Pages deployment to complete.
2. Confirm `https://shanemyrick.com/.well-known/atproto-did` returns the DID.
3. In Bluesky, change the handle to `shanemyrick.com` and verify it.